### PR TITLE
fix(client): fixed the client connection port

### DIFF
--- a/etherdream/src/device.rs
+++ b/etherdream/src/device.rs
@@ -129,6 +129,18 @@ impl State {
   }
 }
 
+impl fmt::Display for State {
+  fn fmt( &self, f: &mut fmt::Formatter ) -> fmt::Result {
+    writeln!( f, "State:" )?;
+    writeln!( f, "  Light engine = {:?}", self.light_engine_state )?;
+    writeln!( f, "  Playback = {:?}", self.playback_state )?;
+    writeln!( f, "  Source = {:?}", self.source )?;
+    writeln!( f, "  Points buffered = {:?}", self.points_buffered )?;
+    writeln!( f, "  Points per second = {:?}", self.points_per_second )?;
+    return writeln!( f, "  Points lifetime = {:?}", self.points_lifetime );
+  }
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Device
 
 /// Encodes a device response from an Etherdream DAC discovery broadcast. 
@@ -172,17 +184,11 @@ impl Device {
 
 impl fmt::Display for Device {
   fn fmt( &self, f: &mut fmt::Formatter ) -> fmt::Result {
-    writeln!( f, "Core properties:" )?;
+    writeln!( f, "Device:" )?;
     writeln!( f, "  Buffer capacity = {}", self.buffer_capacity )?;
     writeln!( f, "  Mac address = {}", self.mac_address )?;
     writeln!( f, "  Max points per second = {}", self.max_points_per_second )?;
     writeln!( f, "  Version = hardware: {}; software: {}", self.version.hardware, self.version.software )?;
-
-    writeln!( f, "\nCurrent state:" )?;
-    writeln!( f, "  Light engine = {:?}", self.state.light_engine_state )?;
-    writeln!( f, "  Playback = {:?}", self.state.playback_state )?;
-    writeln!( f, "  Points lifetime = {:?}", self.state.points_lifetime )?;
-    writeln!( f, "  Points per second = {:?}", self.state.points_per_second )?;
-    return writeln!( f, "  Source = {:?}", self.state.source );
+    return writeln!( f, "\n{}", self.state );
   }
 }

--- a/etherdream/tests/client_tests.rs
+++ b/etherdream/tests/client_tests.rs
@@ -135,7 +135,7 @@ async fn a_ping_will_be_sent_and_acknowledged() {
 
   // Create and start a client
   let client = 
-    client::Client::connect( server.address(), on_command_handler ).await
+    client::Client::connect_with_address( server.address(), on_command_handler ).await
     .expect( "Failed to connect to Etherdream device" );
 
   // Send a ping and assert success

--- a/etherdream/tests/discovery_tests.rs
+++ b/etherdream/tests/discovery_tests.rs
@@ -16,12 +16,12 @@ use support::DeviceBuilder;
 // Starts a discovery server with `limit`. Returns a tuple containing (1) the
 // shared vector that discovered device(s) will be persisted into via callback, 
 // and (2) the connection for the server.
-async fn setup_discovery( limit: usize ) -> ( Arc<RwLock<Vec<( SocketAddr, Device )>>>, discovery::Connection ) {
+async fn setup_discovery( limit: usize ) -> ( Arc<RwLock<Vec<( IpAddr, Device )>>>, discovery::Connection ) {
   let callback_devices = Arc::new( RwLock::new( Vec::new() ) );
   let callback_devices_1 = callback_devices.clone();
 
   let server = 
-    discovery::Server::new( move | address, device | { callback_devices_1.write().push( ( address, device ) ); })
+    discovery::Server::new( move | ip, device | { callback_devices_1.write().push( ( ip, device ) ); })
     .address( SocketAddr::new( IpAddr::V4( Ipv4Addr::LOCALHOST ), 0 ) )
     .duration( Duration::from_secs( 5 ) )
     .limit( limit )
@@ -71,9 +71,9 @@ async fn receives_an_etherdream_broadcast() -> io::Result<()> {
   let callback_devices = callback_devices.read();
 
   assert_eq!( callback_devices.len(), 1 );
-  let &( address, callback_device ) = callback_devices.get( 0 ).unwrap();
+  let &( ip, callback_device ) = callback_devices.get( 0 ).unwrap();
 
-  assert_eq!( address.ip(), IpAddr::V4( Ipv4Addr::LOCALHOST ) );
+  assert_eq!( ip, IpAddr::V4( Ipv4Addr::LOCALHOST ) );
 
   assert_eq!( callback_device.buffer_capacity, 1024 );
   assert_eq!( callback_device.mac_address, MacAddress::new([ 0, 1 , 2, 3, 4, 5 ]) );


### PR DESCRIPTION
### Changelog:

- Fixed the client to use the expected Etherdream connection port, `7765`. Confirmed the fix using the CLI tool.