### PR TITLE
Circular buffer improvements and general client refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.idea
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,6 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 name = "etherdream"
 version = "0.1.0"
 dependencies = [
- "parking_lot",
  "tokio",
  "tokio-util",
 ]
@@ -167,7 +166,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "etherdream",
- "parking_lot",
  "shlex",
  "tokio",
 ]
@@ -406,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,4 @@ resolver = "2"
 members = ["etherdream", "etherdream-cli"]
 
 [workspace.dependencies]
-parking_lot = { version = "0.12.3" }
 tokio = { version = "1", features = ["net"] }

--- a/etherdream-cli/Cargo.toml
+++ b/etherdream-cli/Cargo.toml
@@ -7,6 +7,5 @@ version = "0.1.0"
 [dependencies]
 clap = { version = "4.5.35", features = ["derive"] }
 etherdream = { path = "../etherdream" }
-parking_lot = { workspace=true }
 shlex = { version="1.3.0" }
 tokio = { workspace=true, features=["full"] }

--- a/etherdream-cli/src/main.rs
+++ b/etherdream-cli/src/main.rs
@@ -1,18 +1,13 @@
 use std::collections::HashMap;
 use std::io::{ self, Write };
-use std::net::IpAddr;
-use std::sync::Arc;
+use std::net::SocketAddr;
+use std::sync::{ Arc, RwLock };
 
 use clap;
-use parking_lot::RwLock;
 
-use etherdream::{ self, discovery };
+use etherdream;
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Main
-
-type StateRef = Arc<RwLock<State>>;
-
-struct State {
+struct App {
   // The current client that is active
   current_client: Option<usize>,
 
@@ -20,13 +15,136 @@ struct State {
   clients: HashMap<usize,etherdream::Client>,
 
   // A list of all discovered Etherdream devices (using a vec to allow accessing by index)
-  devices: Vec<( IpAddr, etherdream::Device )>
+  devices: Arc<RwLock<Vec<( SocketAddr, etherdream::Device )>>>
 }
+
+impl App {
+  async fn do_list_devices( &self ) {
+    let devices = self.devices.read().unwrap();
+
+    if devices.is_empty() {
+      println!( "(no devices)" );
+    } else {
+      for ( index, ( ip, device ) ) in devices.iter().enumerate() {
+        println!( "  [{}] {} (MAC: {})", index, ip, device.mac_address );
+      }
+    }
+  }
+
+  async fn do_connect( &mut self, device_index: usize ) {
+
+    // If client already exists, set it as the current device
+    if self.clients.contains_key( &device_index ) {
+      self.current_client = Some( device_index );
+    }
+
+    // Create a new client for the device at `device_index`
+    else {
+      let devices = self.devices.read().unwrap();
+
+      match devices.get( device_index ) {
+        Some( &( socket, _device ) ) => {
+          match etherdream::Client::new( socket ).await {
+            Ok( client ) => {
+              self.clients.insert( device_index, client );
+              self.current_client = Some( device_index );
+            }
+
+            Err( msg ) => {
+              println!( "Failed to connect to Etherdream DAC: {}", msg );
+            }
+          }
+        },
+
+        None => {
+          println!( "(does not exist)" );
+        }
+      }
+    }
+  }
+
+  async fn do_disconnect( &mut self ) {
+    if let Some( index ) = self.current_client {
+      if let Some( client ) = self.clients.remove( &index ) {
+        let _ = client.disconnect().await;
+      }
+    }
+  }
+
+  async fn do_print_device_info( &self, device_index: usize ) {
+    let devices = self.devices.read().unwrap();
+
+    match devices.get( device_index ) {
+      Some(( ip, device )) => {
+        println!( "IP = {ip}\n" );
+        print_device( &device );
+      },
+      None => {
+        println!( "(does not exist)" );
+      }
+    }
+  }
+
+  async fn do_ping_current_device( &mut self ) {
+    if let Some( client_index ) = self.current_client {
+      let client = self.clients.get_mut( &client_index ).unwrap();
+
+      match client.ping().await {
+        Ok( state ) => {
+          println!( "Acknowledged: yes" );
+          print_device_state( &state );
+        },
+        _ => println!( "Ping error..." )
+      }
+    } else {
+      println!( "(no device connected)" );
+    }
+  }
+
+  async fn do_play_current_device( &mut self ) {
+    if let Some( client_index ) = self.current_client {
+      let client = self.clients.get_mut( &client_index ).unwrap();
+
+      for _ in 0..3000 {
+        client.push_point( 0, 0, u16::MAX, u16::MAX, u16::MAX );
+      }
+
+      // Temporarily sleep for a moment...
+      //tokio::time::sleep( tokio::time::Duration::from_secs( 1 ) ).await;
+
+      // Start...
+      client.start( 1500 );
+
+    } else {
+      println!( "(no device connected)" );
+    }
+  }
+
+  async fn do_reset_current_device( &mut self ) {
+    if let Some( client_index ) = self.current_client {
+      let client = self.clients.get_mut( &client_index ).unwrap();
+      let _ = client.reset().await;
+    } else {
+      println!( "(no device connected)" );
+    }
+  }
+
+  fn do_print_status_current_device( &self ) {
+    if let Some( client_index ) = self.current_client {
+      let client = self.clients.get( &client_index ).unwrap();
+      print_device_state( &client.state() );
+    } else {
+      println!( "(no device connected)" );
+    }
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Main
 
 #[tokio::main]
 async fn main() {
   let mut input = String::new();
-  let state = Arc::new( RwLock::new( State{ clients: HashMap::new(), current_client: None, devices: Vec::new() }));
+  let mut app = App{ clients: HashMap::new(), current_client: None, devices: Arc::new( RwLock::new( Vec::new() ) ) };
 
   let mut cli = clap::Command::new( "Etherdream" )
     .about( "Discover and manage Etherdream devices." )
@@ -41,30 +159,41 @@ async fn main() {
         .arg( clap::Arg::new( "index" ).required( true ).value_parser( clap::value_parser!( usize ) ) ),
       clap::Command::new( "connect" )
         .about( "Connects to a discovered Etherdream device at the provided `index`." )
-        .arg( clap::Arg::new( "index" ).required( true ).value_parser( clap::value_parser!( usize ) ) ),
+        .arg( clap::Arg::new( "index" ).required( true ).value_parser( clap::value_parser!( usize ) ) )
+        .visible_alias( "cd" ),
       clap::Command::new( "disconnect" )
         .about( "Disconnects from the currently active Etherdream device." ),
       clap::Command::new( "ping" )
         .about( "Pings the currently active Etherdream device and prints the active device state." ),
+      clap::Command::new( "play" )
+        .about( "..." ),
+      clap::Command::new( "reset" )
+        .about( "(tmp) empties the point buffer in the DAC" ),
+      clap::Command::new( "status" )
+        .about( "(tmp) returns the last reported status from the DAC (non-ping)" ),
       clap::Command::new( "exit" )
     ]);
 
-  // Start the Etherdream discovery service. All discovered devices will be
-  // stored in `state.devices`.
+  // Start the Etherdream discovery service. All discovered devices will be stored in
+  // `state.devices`.
   tokio::task::spawn({
-    let state = state.clone();
+    let devices = app.devices.clone();
 
     async move {
-      return discovery::Server::new( move | ip, device | { state.write().devices.push( ( ip, device ) ); })
+      etherdream::Discovery::new(
+        move | socket, device | {
+          // Safety: Unwrap is safe, as this is the only write invocation in discovery thread.
+          devices.write().unwrap().push( ( socket, device ) );
+        })
         .serve()
-        .await;
+        .await
     }
   });
 
   // REPL
   loop {
     // Print console prefix, one of "> " or "[<device index>] >"
-    let prefix = if let Some( index ) = state.read().current_client { format!( "[{}] ", index ) } else { String::from( "" ) };
+    let prefix = if let Some( index ) = app.current_client { format!( "[{}] ", index ) } else { String::from( "" ) };
     print!( "{}> ", prefix );
   
     // Read and parse console input
@@ -76,12 +205,15 @@ async fn main() {
       match cli.try_get_matches_from_mut( args ) {
         Ok( matches ) =>
           match matches.subcommand() {
-            Some(( "connect", args )) => do_connect( &state, *args.get_one::<usize>( "index" ).unwrap() ).await,
-            Some(( "disconnect", _ )) => do_disconnect( &state ).await,
+            Some(( "connect", args )) => app.do_connect( *args.get_one::<usize>( "index" ).unwrap() ).await,
+            Some(( "disconnect", _ )) => app.do_disconnect().await,
             Some(( "exit", _ )) => break,
-            Some(( "info", args )) => do_print_device_info( &state, *args.get_one::<usize>( "index" ).unwrap() ),
-            Some(( "list", _ )) => do_list_devices( &state ),
-            Some(( "ping", _ )) => do_ping_current_device( &state ).await,
+            Some(( "info", args )) => app.do_print_device_info( *args.get_one::<usize>( "index" ).unwrap() ).await,
+            Some(( "list", _ )) => app.do_list_devices().await,
+            Some(( "ping", _ )) => app.do_ping_current_device().await,
+            Some(( "status", _ )) => app.do_print_status_current_device(),
+            Some(( "play", _ )) => app.do_play_current_device().await,
+            Some(( "reset", _ )) => app.do_reset_current_device().await,
             _ => {}
           },
         Err( err ) => 
@@ -91,94 +223,32 @@ async fn main() {
   }
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Command Handlers
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  Helpers
 
-fn do_list_devices( state: &StateRef ) {
-  let state = state.read();
+fn print_device( device: &etherdream::Device ) {
+  println!( "Device:" );
+  println!( "  Buffer capacity = {}", device.buffer_capacity );
+  println!( "  Mac address = {}", device.mac_address );
+  println!( "  Max points per second = {}", device.max_points_per_second );
+  println!( "  Version = hardware: {}; software: {}", device.version.hardware, device.version.software );
+  println!( "State:" );
 
-  if state.devices.is_empty() {
-    println!( "(no devices)" );
-  } else {
-    for ( index, ( ip, device ) ) in state.devices.iter().enumerate() {
-      println!( "  [{}] {} (MAC: {})", index, ip, device.mac_address );
-    }
-  }
+  print_device_state( &device.state );
 }
 
-async fn do_connect( state: &StateRef, device_index: usize ) {
-  // Define client command callback
-  let callback_fn = {
-    move | _control, _command, _points_remaining | { 
-      //println!( "COMMAND RECEIVED: {:?}", command );
-    }
-  };
+fn print_device_state( state: &etherdream::device::State ) {
+  let shutter_state = 1 & ( state.playback_flags >> 0 );
+  let underflow_state = 1 & ( state.playback_flags >> 1 );
+  let e_stop_state = 1 & ( state.playback_flags >> 2 );
 
-  let mut state = state.write();
-
-  // If client already exists, set it as the current device
-  if state.clients.contains_key( &device_index ) {
-    state.current_client = Some( device_index );
-  } 
-  
-  // Create a new client for the device at `device_index`
-  else {
-    match state.devices.get( device_index ) {
-      Some( &( ip, _ ) ) => {
-        match etherdream::Client::connect( ip, callback_fn ).await {
-          Ok( client ) => {
-            state.clients.insert( device_index, client );
-            state.current_client = Some( device_index );
-          }
-
-          Err( msg ) => {
-            println!( "Failed to connect to Etherdream DAC: {}", msg ); 
-          }
-        }
-      },
-
-      None => { 
-        println!( "(does not exist)" ); 
-      }
-    }
-  }
-}
-
-async fn do_disconnect( state: &StateRef ) {
-  let mut state = state.write();
-
-  if let Some( index ) = state.current_client {
-    if let Some( client ) = state.clients.remove( &index ) {
-      let _ = client.disconnect().await;
-    }
-  }
-}
-
-fn do_print_device_info( state: &StateRef, device_index: usize ) {
-  match state.read().devices.get( device_index ) {
-    Some(( ip, device )) => {
-      println!( "IP = {ip}\n" );
-      println!( "{device}" );
-    },
-    None => { 
-      println!( "(does not exist)" ); 
-    }
-  }
-}
-
-async fn do_ping_current_device( state: &StateRef ) {
-  let state = state.read();
-
-  if let Some( client_index ) = state.current_client {
-    let client = state.clients.get( &client_index ).unwrap();
-    
-    match client.ping().await {
-      Ok( state ) => {
-        println!( "Acknowledged: yes" );
-        println!( "\n{state}" );
-      },
-      _ => println!( "Ping error..." )
-    }
-  } else {
-    println!( "(no device connected)" );
-  }
+  println!( "  Light engine = {:?}", state.light_engine_state );
+  println!( "  Light engine flag = {:?}", state.light_engine_flags );
+  println!( "  Playback = {:?}", state.playback_state );
+  println!( "    Shutter = {:?}", shutter_state );
+  println!( "    Underflow = {:?}", underflow_state );
+  println!( "    E-stop = {:?}", e_stop_state );
+  println!( "  Source = {:?}", state.source );
+  println!( "  Points buffered = {:?}", state.points_buffered );
+  println!( "  Points per second = {:?}", state.points_per_second );
+  println!( "  Points lifetime = {:?}", state.points_lifetime );
 }

--- a/etherdream/Cargo.toml
+++ b/etherdream/Cargo.toml
@@ -5,9 +5,8 @@ name = "etherdream"
 version = "0.1.0"
 
 [dependencies]
-parking_lot = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { version = "0.7.15", features = ["net"] }
+tokio-util = { version = "0.7.16", features = ["net"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/etherdream/src/circular_buffer.rs
+++ b/etherdream/src/circular_buffer.rs
@@ -1,0 +1,196 @@
+//! A bounded single-producer single-consumer (SPSC) circular buffer.
+use std::mem::ManuallyDrop;
+use std::sync::{ Arc, atomic::{ AtomicUsize, Ordering } };
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  Circular Buffer
+
+pub struct CircularBuffer<T, const CAPACITY: usize> {
+  data: *mut T,
+  size: AtomicUsize
+}
+
+impl<T, const CAPACITY: usize> CircularBuffer<T, CAPACITY>
+where T: Copy + Clone + Default + Send
+{
+  /// Creates a new single-producer single-consumer (SPSC) bounded circular buffer.
+  pub fn new() -> ( Writer<T, CAPACITY>, Reader<T, CAPACITY> )
+  {
+    let buffer = Arc::new( CircularBuffer::<T, CAPACITY>{
+      data: ManuallyDrop::new( Box::new( [T::default(); CAPACITY] ) ).as_mut_ptr(),
+      size: AtomicUsize::new( 0 )
+    });
+
+    (
+      Writer::<T, CAPACITY> { buffer: buffer.clone(), head: 0 },
+      Reader::<T, CAPACITY> { buffer: buffer.clone(), tail: 0 }
+    )
+  }
+}
+
+impl<T, const CAPACITY: usize> Drop for CircularBuffer<T, CAPACITY> {
+  fn drop( &mut self ) {
+    // SAFETY: Compliment to the `ManuallyDrop` that wraps `data`.
+    unsafe { drop( Box::from_raw( self.data ) ) };
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Reader
+
+pub struct Reader<T, const CAPACITY: usize>
+{
+  buffer: Arc<CircularBuffer<T, CAPACITY>>,
+  tail: usize
+}
+
+impl<T, const CAPACITY: usize> Reader<T, CAPACITY>
+{
+  /// Returns true if the buffer is empty
+  pub fn is_empty( &self ) -> bool {
+    self.len() == 0
+  }
+
+  /// Returns true if the buffer is at capacity
+  pub fn is_full( &self ) -> bool { 
+    self.len() == CAPACITY
+  }
+
+  /// Returns the count of unread items in the buffer
+  pub fn len( &self ) -> usize {
+    self.buffer.size.load( Ordering::Relaxed )
+  }
+
+  /// Returns the count of remaining capacity in the buffer
+  pub fn remaining( &self ) -> usize {
+    CAPACITY - self.len()
+  }
+
+  /// Returns the maximum capacity of the buffer
+  pub fn capacity( &self ) -> usize {
+    CAPACITY
+  }
+
+  /// Returns the currently available item (if one is available) and advances the head. If the
+  /// buffer is empty, returns None.
+  pub fn pop( &mut self ) -> Option<T> {
+    if self.is_empty() {
+      return None;
+    }
+
+    let item = unsafe{ self.buffer.data.add( self.tail ).read() };
+    self.tail = ( self.tail + 1 ) % CAPACITY;
+    self.buffer.size.fetch_sub( 1, Ordering::Relaxed );
+    Some( item )
+  }
+}
+
+// SAFETY:
+// * Compile-time guarantee that there is only one writer to the shared buffer.
+// * Logical guarantee that the writer will never access the reader's tail.
+unsafe impl<T: Send, const CAPACITY: usize> Send for Reader<T,CAPACITY> {}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Writer
+
+pub struct Writer<T, const CAPACITY: usize>
+{
+  buffer: Arc<CircularBuffer<T, CAPACITY>>,
+  head: usize
+}
+
+impl<T, const CAPACITY: usize> Writer<T, CAPACITY>
+{
+  /// Returns true if the buffer is empty
+  pub fn is_empty( &self ) -> bool {
+    self.len() == 0
+  }
+
+  /// Returns true if the buffer is at capacity
+  pub fn is_full( &self ) -> bool { 
+    self.len() == CAPACITY
+  }
+
+  /// Returns the count of unread items in the buffer
+  pub fn len( &self ) -> usize {
+    self.buffer.size.load( Ordering::Relaxed )
+  }
+
+  /// Returns the count of remaining capacity in the buffer
+  pub fn remaining( &self ) -> usize {
+    CAPACITY - self.len()
+  }
+
+  /// Returns the maximum capacity of the buffer
+  pub fn capacity( &self ) -> usize {
+    CAPACITY
+  }
+
+  /// Pushes `item` into the buffer (if space is available) and advances the tail. If the buffer is
+  /// full, returns a PushError.
+  pub fn push( &mut self, item: T ) -> Result<(),PushError> {
+    if self.is_full() {
+      return Err( PushError::InsufficientCapacity );
+    }
+
+    unsafe{ self.buffer.data.add( self.head ).write( item ); }
+    self.head = ( self.head + 1 ) % CAPACITY;
+    let _size = self.buffer.size.fetch_add( 1, Ordering::Relaxed );
+    Ok(())
+  }
+}
+
+// SAFETY:
+// * Compile-time guarantee that there is only one reader to the shared buffer.
+// * Logical guarantee that the reader will never consume from the writer's head.
+unsafe impl<T: Send, const CAPACITY: usize> Send for Writer<T,CAPACITY> {}
+
+#[derive( Debug, PartialEq )]
+pub enum PushError {
+  InsufficientCapacity
+}
+
+/*
+  //
+  pub fn push_from_slice( &mut self, points: &[T] ) -> Result<(),BoundedCircularBufferError> {
+    let mut remaining = self.capacity();
+
+    if points.len() > remaining {
+      return Err( BoundedCircularBufferError::InsufficientCapacity );
+    }
+
+    /*
+    Possibilities:
+    r [w - - - - -]
+      [r - w - - -]
+      [- - r - w -]
+      [- - - r - w]
+      [w - - - r -]
+      [- r w - - -]
+     */
+
+    //
+    //let mut amount;
+    remaining = usize::min( remaining, points.len() );
+
+    // Push into any available tail-space
+    if self.write >= self.read {
+      //amount = min( N - self.write, remaining );
+      //self.buffer[self.write..( self.write + amount )].copy_from_slice( &points[..amount] );
+      //remaining -= amount;
+    }
+
+    // Push into any available head-space
+    if remaining > 0 && self.read < self.write {
+      //amount = min( self.read, points.len() );
+      //self.buffer[..remaining].copy_from_slice( &points[..amount] );
+    }
+
+    //
+    //self.write = ( self.write + points.len() ) % N;
+
+    return Ok(());
+  }
+
+  pub fn pop_into_slice( &mut self, _points: &mut [T] ) {
+    
+  }
+}
+*/

--- a/etherdream/src/client.rs
+++ b/etherdream/src/client.rs
@@ -1,7 +1,8 @@
-use std::net::{ IpAddr, SocketAddr };
-use std::sync::Arc;
+//! A client that can communicate with an Etherdream DAC.
+use std::net::SocketAddr;
+use std::sync::{ Arc, RwLock };
+use std::time::Instant;
 
-use parking_lot::RwLock;
 use tokio::io::{ self, AsyncReadExt, AsyncWriteExt };
 use tokio::net::{ self, tcp::{ OwnedReadHalf, OwnedWriteHalf } };
 use tokio::sync::{ mpsc, oneshot };
@@ -9,104 +10,84 @@ use tokio::task;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
 
-use crate::device::{self, DEFAULT_PORT, DEVICE_STATE_BYTES_SIZE};
+use crate::circular_buffer;
+use crate::device;
 
-const DAC_COMMAND_PING: u8              = b'?';
-const DAC_CONTROL_ACK: u8               = b'a';
-const DAC_CONTROL_NAK: u8               = b'F';
-const DAC_CONTROL_INVALID: u8           = b'I';
-const DAC_CONTROL_STOP: u8              = b'!';
-const DAC_RESPONSE_CONTROL_SIZE: usize  = 2;
-const DAC_RESPONSE_SIZE: usize          = DAC_RESPONSE_CONTROL_SIZE + device::DEVICE_STATE_BYTES_SIZE;
+const DAC_COMMAND_BEGIN: u8         = b'b';
+const DAC_COMMAND_CLEAR: u8         = b'c';
+const DAC_COMMAND_DATA: u8          = b'd';
+const DAC_COMMAND_PING: u8          = b'?';
+const DAC_COMMAND_PREPARE: u8       = b'p';
+const DAC_COMMAND_STOP: u8          = b's';
+const DAC_CONTROL_ACK: u8           = b'a';
+const DAC_CONTROL_NAK_FULL: u8      = b'F';
+const DAC_CONTROL_NAK_INVALID: u8   = b'I';
+const DAC_CONTROL_NAK_STOP: u8      = b'!';
 
-type PointsBuffered = u16;
+const DEFAULT_CLIENT_POINT_CAPACITY: usize = 30_000;
 
-type DeviceStateBytes   = [u8;device::DEVICE_STATE_BYTES_SIZE];
-type DeviceStateRef     = Arc<RwLock<DeviceStateBytes>>;
+type InstantRef = Arc<RwLock<Instant>>;
+type PointBufferType = ( i16, i16, u16, u16, u16 );
+type StateRef = Arc<RwLock<device::State>>;
+type WaitingCommandCallbackRef = Arc<RwLock<Option<( Command, oneshot::Sender<device::State> )>>>;
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Control Signal
+// Used internally to send commands from the Client thread to the asynchronous DAC tx thread.
+#[derive( Clone, Copy )]
+enum Command {
+  Begin{ rate: u32 },
+  Clear,
+  Ping,
+  Prepare,
+  Stop
+}
 
-#[repr( u8 )]
 #[derive( Debug )]
-pub enum ControlSignal {
-  // The previous command was accepted.
-  Ack = DAC_CONTROL_ACK,
-
-  // The write command could not be performed because there was not
-  // enough buffer space when it was received.
-  Nak = DAC_CONTROL_NAK,
-
-  // The command contained an invalid command byte or parameters.
-  Invalid = DAC_CONTROL_INVALID,
-
-  // An emergency-stop condition exists.
-  Stop = DAC_CONTROL_STOP
-}
-
-impl ControlSignal {
-  pub fn from_byte( signal: u8 ) -> Option<Self> {
-    return match signal {
-      DAC_CONTROL_ACK      => Some( ControlSignal::Ack ),
-      DAC_CONTROL_NAK      => Some( ControlSignal::Nak ),
-      DAC_CONTROL_INVALID  => Some( ControlSignal::Invalid ),
-      DAC_CONTROL_STOP     => Some( ControlSignal::Stop ),
-      _                    => None
-    };
-  }
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  Command
-
-#[repr( u8 )]
-#[derive( Debug )]
-pub enum Command {
-  Ping    = DAC_COMMAND_PING
-}
-
-impl Command {
-  pub fn from_byte( command: u8 ) -> Option<Self> {
-    return match command {
-      DAC_COMMAND_PING  => Some( Command::Ping ),
-      _                 => None
-    };
-  }
+pub enum CommandError {
+  Failed,
+  Timeout
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Client
 
-pub struct Client {
-  // The remote address for the Etherdream DAC
+/// A client that can communicate with an Etherdream DAC.
+pub struct Client<const N: usize = DEFAULT_CLIENT_POINT_CAPACITY> {
+  // The remote address of the Etherdream DAC.
   address: SocketAddr,
-
-  // Token used to shutdown the asynchronous client tasks
-  shutdown_token: CancellationToken,
 
   // Channel used to send commands from the client to the async writer task
   command_tx: mpsc::Sender<Command>,
-  
+
+  // The time that the client was created
+  created_at: Instant,
+
+  // The time that the client last received a message from the DAC
+  last_seen_at: InstantRef,
+
+  // The buffer writer to send points to
+  point_tx: circular_buffer::Writer<PointBufferType,N>,
+
+  // Token used to shut down asynchronous client tasks
+  shutdown_token: CancellationToken,
+
+  // The last recorded state of the Etherdream DAC
+  state: StateRef,
+
   // The clients async task handles
   tasks: Option<[task::JoinHandle<io::Result<()>>; 2]>,
 
-  // The last recorded state of the Etherdream DAC
-  _state: DeviceStateRef,
-
-  // Channel used to acknowledge user-initiated ping requests
-  ping_notifier: Arc<RwLock<Option<oneshot::Sender<device::State>>>>
+  // The sender of a one-shot channel used for `send_command_and_wait` calls
+  waiting_command_callback: WaitingCommandCallbackRef,
 }
  
-impl Client {
-  pub async fn connect<T>( ip: IpAddr, on_command_handler: T ) -> io::Result<Client>
-    where T: Fn( ControlSignal, Command, PointsBuffered ) + Send + 'static
-  {  
-    return Self::connect_with_address( SocketAddr::new( ip, DEFAULT_PORT ), on_command_handler ).await;
-  }
-
-  pub async fn connect_with_address<T>( address: SocketAddr, on_command_handler: T ) -> io::Result<Client>
-    where T: Fn( ControlSignal, Command, PointsBuffered ) + Send + 'static
+impl<const N: usize> Client<N> {
+  /// Creates a new client using a SocketAddr.
+  pub async fn new( address: SocketAddr ) -> io::Result<Client<N>>
   {
-    let ping_notifier = Arc::new( RwLock::new( None::<oneshot::Sender<device::State>> ) );
+    let last_seen_at = Arc::new( RwLock::new( Instant::now() ) );
+    let ( point_tx, point_rx ) = circular_buffer::CircularBuffer::<PointBufferType,N>::new();
     let shutdown_token = CancellationToken::new();
-    let state = Arc::new( RwLock::new( DeviceStateBytes::default() ) );
+    let state = Arc::new( RwLock::new( device::State::default() ) );
+    let waiting_command_callback = Arc::new( RwLock::new( None ) );
 
     // Responsible to communicating commands from the client run-time to the
     // asynchronous DAC writer, `do_write`
@@ -117,45 +98,104 @@ impl Client {
     let ( dac_rx, dac_tx ) = dac_stream.into_split();
 
     // Start the DAC read handler
-    let dac_rx_handle = {
-      let shutdown_token = shutdown_token.child_token();
-
+    let dac_rx_handle =
       tokio::spawn({
-        let ping_notifier = ping_notifier.clone();
+        let command_callback = waiting_command_callback.clone();
+        let last_seen_at = last_seen_at.clone();
+        let shutdown_token = shutdown_token.child_token();
         let state = state.clone();
 
         async move {
           tokio::select!{
             _ = shutdown_token.cancelled() => { Ok(()) }
-            result = do_read( state, dac_rx, on_command_handler, ping_notifier ) => { result }
+            result = do_read( dac_rx, state, last_seen_at, command_callback ) => { result }
           }
         }
-      })
-    };
+      });
 
     // Start the DAC write handler
-    let dac_tx_handle = {
-      let shutdown_token = shutdown_token.child_token();
+    let dac_tx_handle =
+      tokio::spawn({ 
+        let shutdown_token = shutdown_token.child_token();
 
-      tokio::spawn( async move {
-        tokio::select!{
-          _ = shutdown_token.cancelled() => { Ok(()) }
-          result = do_write( command_rx, dac_tx ) => { result }
+        async move {
+          tokio::select!{
+            _ = shutdown_token.cancelled() => { Ok(()) }
+            result = do_write::<N>( dac_tx, command_rx, point_rx ) => { result }
+          }
         }
-      })
+      });
+    
+    let mut client = Client{ 
+      address,
+      command_tx,
+      created_at: Instant::now(),
+      last_seen_at,
+      point_tx,
+      shutdown_token,
+      state,
+      tasks: Some([ dac_rx_handle, dac_tx_handle ]),
+      waiting_command_callback
     };
 
-    return Ok( Client{ 
-      address: address,
-      command_tx: command_tx,
-      ping_notifier: ping_notifier,
-      shutdown_token: shutdown_token,
-      _state: state,
-      tasks: Some([ dac_rx_handle, dac_tx_handle ])
-    });
+    // Reset the Etherdream DAC which:
+    // (1) ensures the DAC is prepared to receive point data, and...
+    // (2) ensures the DAC's most current state is reflected in our client.
+    match client.reset().await {
+      Ok( _ ) => Ok( client ),
+      Err( _error ) => Err( io::Error::other( "" ) )
+    }
   }
 
-  // Stops the client and consumes self. Returns Ok on success.
+  /// Returns the socket address that the Etherdream DAC is connected to.
+  pub fn remote( &self ) -> &SocketAddr {
+    &self.address
+  }
+
+  /// Returns the most recently recorded Etherdream DAC state. For the most up-to-date information,
+  /// use `ping`.
+  pub fn state( &self ) -> device::State {
+    *self.state.read().unwrap()
+  }
+
+  /// Returns the duration of time that the client has been active for.
+  pub fn elapsed_time( &self ) -> time::Duration {
+    *self.last_seen_at.read().unwrap() - self.created_at
+  }
+
+  /// Sends a ping to the Etherdream DAC and awaits a response.
+  pub async fn ping( &mut self ) -> Result<device::State,CommandError> {
+    self.send_command_and_wait( Command::Ping ).await
+  }
+
+  /// Resets the Etherdream DAC to a "prepared" state that is ready to receive point data. Will
+  /// clear any E-stop flags, if set.
+  pub async fn reset( &mut self ) -> Result<device::State,CommandError> {
+    match self.send_command_and_wait( Command::Clear ).await {
+      Ok( _ ) => self.send_command_and_wait( Command::Prepare ).await,
+      error => error
+    }
+  }
+
+  /// Pushes a single point into the clients internal point buffer. Point data will be
+  /// asynchronously streamed to the Etherdream DAC.
+  ///
+  /// TODO: Allow for queue rate change.
+  pub fn push_point( &mut self, x: i16, y: i16, r: u16, g: u16, b: u16 ) {
+    let _ = self.point_tx.push(( x, y, r, g, b ));
+  }
+
+  /// Sends a message to the DAC to start playing point data at the provided `rate`.
+  pub fn start( &self, rate: u32 ) {
+    let _ = self.command_tx.try_send( Command::Begin{ rate } );
+  }
+
+  /// Sends a message to the DAC to stop playing point data.
+  pub async fn stop( &mut self ) -> Result<device::State,CommandError> {
+    self.send_command_and_wait( Command::Stop ).await
+  }
+
+  /// Stops the client and consumes `self`.
   pub async fn disconnect( mut self ) -> Result<(),task::JoinError> {
     self.shutdown_token.cancel();
 
@@ -165,91 +205,221 @@ impl Client {
       }
     }
 
-    return Ok(());
+    Ok(())
   }
 
-  // Return the remote address for the DAC that this client is connected to.
-  pub fn remote( &self ) -> SocketAddr {
-    return self.address;
-  }
+  // Private routine to send a command to the Etherdream DAC and wait for an ACK, or timeout.
+  async fn send_command_and_wait( &mut self, command: Command ) -> Result<device::State,CommandError> {
+    // Set up a oneshot channel. The sender is stored in our client and will be consumed by the
+    // DAC rx thread when a response is received that matches `command`.
+    let ( waiting_command_tx, waiting_command_rx ) = oneshot::channel::<device::State>();
+    *self.waiting_command_callback.write().unwrap() = Some( ( command, waiting_command_tx ) );
 
-  // Send a ping request to the DAC. Response will be delivered asynchronously
-  // via the user-provided callback.
-  pub async fn ping( &self ) -> Result<device::State,String> {
-    //
-    let( ping_tx, ping_rx ) = tokio::sync::oneshot::channel::<device::State>();
-    *self.ping_notifier.write() = Some( ping_tx );
+    // Send the command
+    let _ = self.command_tx.try_send( command );
 
-    //
-    let result = time::timeout( time::Duration::from_secs( 2 ), async move {
-      let _ = self.command_tx.try_send( Command::Ping );
-      
-      if let Ok( state ) = ping_rx.await {
-        return Ok( state );
-      } else {
-        return Err( String::from( "failed" ) );
+    // Wait for the acknowledgement or timeout
+    let result = time::timeout( time::Duration::from_secs( 2 ), waiting_command_rx ).await;
+
+    match result {
+      Ok( Ok( result ) ) =>
+        Ok( result ),
+      Ok( Err( _ ) ) =>
+        Err( CommandError::Failed ),
+      Err( _ ) => {
+        // The shared oneshot channel sender should be reset since this is a timeout
+        *self.waiting_command_callback.write().unwrap() = None;
+        Err( CommandError::Timeout )
       }
-    }).await;
-
-    return match result.unwrap() {
-      Ok( result ) => Ok( result ),
-      _ => Err( String::from( "CLIENT: Ping timed out..." ) )
     }
   }
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - -  Private async task handlers
+// ==================================================================== Private
 
-async fn do_read<T>( current_state: DeviceStateRef, mut dac_rx: OwnedReadHalf, on_command_handler: T, ping_notifier: Arc<RwLock<Option<oneshot::Sender<device::State>>>> ) -> io::Result<()> 
-  where T: Fn( ControlSignal, Command, PointsBuffered ) + Send + 'static
+// The DAC will echo back every request with a response that uses this byte layout:
+//
+// | byte(s)  | description       |
+//  ------------------------------
+// | 0        | Control Signal    |
+// | 1        | Command           |
+// | 2-22     | DAC State         |
+//
+// Definitions:
+// Control Signal     One of Ack ('a'), Nak Full ('F'), Nak Invalid ('I') or Nak Stop ('!').
+// Command            The command that this response is an echo for. Responses are always sent in
+//                    the same order as the requests.
+// DAC State          The current device state. Read the documentation of `device::State` for the
+//                    byte layout.
+async fn do_read(
+  mut dac_rx: OwnedReadHalf,
+  current_state: StateRef,
+  last_seen_at: InstantRef,
+  waiting_command_callback: WaitingCommandCallbackRef
+) -> io::Result<()>
 {
-  let mut buf = [0u8; DAC_RESPONSE_SIZE];
+  let mut buf = [0u8; 22];
+  let mut state: device::State;
+  let mut state_bytes = [0; device::DEVICE_STATE_BYTES_SIZE];
 
   loop {
     let _ = dac_rx.read_exact( &mut buf ).await?;
-    
-    // Unpack control data
-    let control_signal = ControlSignal::from_byte( buf[0] );
-    let command = Command::from_byte( buf[1] );
 
-    // Copy the state from our buffer into the client
-    current_state.write().copy_from_slice( &buf[2..] );
+    //
+    *last_seen_at.write().unwrap() = Instant::now();
 
-    match control_signal {
-      Some( ControlSignal::Ack ) => {
-        match command {
-          Some( Command::Ping ) => {
-            //
-            on_command_handler( ControlSignal::Ack, Command::Ping, 0 );
+    //
+    state_bytes.copy_from_slice( &buf[2..] );
+    state = device::State::from_bytes( state_bytes );
+    *current_state.write().unwrap() = state;
 
-            if let Some( notifier ) = ping_notifier.write().take() {
-              // TODO: this can be more efficient...
-              let mut state_bytes = [0; DEVICE_STATE_BYTES_SIZE];
-              state_bytes.copy_from_slice( &buf[2..] );
-
-              let _ = notifier.send( device::State::from_bytes( state_bytes ) );
+    // Unpack the control signal in byte 0
+    match buf[0] {
+      DAC_CONTROL_ACK => {
+        // Unpack the command in byte 1
+        match buf[1] {
+          unknown_command => {
+            println!( "ACK CMD = {}", unknown_command as char );
+            if let Some( ( _cmd, callback2 ) ) = waiting_command_callback.write().unwrap().take() {
+              let _ = callback2.send( state );
             }
-          },
-          _ => {
-            // todo: log warning? error-like callback?
           }
         }
       },
+      DAC_CONTROL_NAK_FULL => {
+        println!( "[NAK FULL]: {}", buf[1] );
+      },
+      DAC_CONTROL_NAK_INVALID => {
+        println!( "[NAK INVALID]" );
+      },
+      DAC_CONTROL_NAK_STOP => {
+        println!( "[NAK E-STOP]" );
+      },
       _ => {
-        todo!();
+        println!( "[an unknown control signal was received]" )
       }
     }
   }
 }
 
-async fn do_write( mut command_rx: mpsc::Receiver<Command>, mut dac_tx: OwnedWriteHalf ) -> io::Result<()> {
-  loop {
-    while let Some( command ) = command_rx.recv().await {
-      match command {
-        Command::Ping => {
+async fn do_write<const N: usize>(
+  mut dac_tx: OwnedWriteHalf,
+  mut command_rx: mpsc::Receiver<Command>,
+  mut point_rx: circular_buffer::Reader<PointBufferType,N>,
+) -> io::Result<()> {
+  let mut data = vec!( 0u8; N * 20 ); // TODO: right-size this packed data buffer.
+  let mut index: usize = 0;
+
+  // Responsible to sending all command and point data to the Etherdream DAC.
+  'primary_loop: loop {
+
+    // Will break out of loop once all commands have been sent.
+    'command_loop: loop {
+
+      if ! point_rx.is_empty() {
+        //let _count = estimate_dac_buffer_count( state, last_seen_at );
+        let point_count = point_rx.len() as u16;
+
+        data[0] = DAC_COMMAND_DATA;
+        data[1..3].copy_from_slice( &u16::to_le_bytes( point_count ) ); // number of points
+
+        for point_index in 0..point_count {
+          if let Some(( x, y, r, g, b )) = point_rx.pop() {
+            index = ( point_index as usize * 18 ) + 3;
+
+            data[index..index+2].fill( 0 ); // control (unused)
+            data[index+2..index+4].copy_from_slice( &i16::to_le_bytes( x ) );
+            data[index+4..index+6].copy_from_slice( &i16::to_le_bytes( y ) );
+            data[index+6..index+8].copy_from_slice( &u16::to_le_bytes( r ) );
+            data[index+8..index+10].copy_from_slice( &u16::to_le_bytes( g ) );
+            data[index+10..index+12].copy_from_slice( &u16::to_le_bytes( b ) );
+            data[index+12..index+14].copy_from_slice( &u16::to_le_bytes( u16::MAX ) );
+            data[index+14..index+18].fill( 0 );
+
+            index += 18;
+          } else {
+            break;
+          }
+        }
+
+        let _ = dac_tx.write( &data[..index] ).await?;
+      }
+
+      //
+      match command_rx.try_recv() {
+        Ok( Command::Ping ) => {
           let _ = dac_tx.write_u8( DAC_COMMAND_PING ).await?;
+        },
+        Ok( Command::Prepare ) => {
+          let _ = dac_tx.write_u8( DAC_COMMAND_PREPARE ).await?;
+        },
+        Ok( Command::Begin{ rate } ) => {          
+          data[0] = DAC_COMMAND_BEGIN;
+          data[1..3].fill( 0 );
+          data[3..7].copy_from_slice( &u32::to_le_bytes( rate ) );
+
+          let _ = dac_tx.write( &data[..7] ).await?;
+        },
+        Ok( Command::Clear ) => {
+          let _ = dac_tx.write_u8( DAC_COMMAND_CLEAR ).await?;
+        },
+        Ok( Command::Stop ) => {
+          let _ = dac_tx.write_u8( DAC_COMMAND_STOP ).await?;
+        },
+        Err( mpsc::error::TryRecvError::Empty ) => {
+          // All commands have been sent, break out of the command loop
+          break 'command_loop;
+        },
+        Err( mpsc::error::TryRecvError::Disconnected ) => {
+          // The command sender has hung up, gracefully exit this routine
+          break 'primary_loop;
         }
       }
     }
+
+    // ...
+    tokio::time::sleep( time::Duration::from_micros( 100 ) ).await;
   }
+
+  Ok( () )
 }
+
+/*
+// Returns an u16 based on the scaled `amount` in range [0.0, 1.0]
+fn scaled_u16( amount: f32 ) -> u16 {
+  ( u16::MAX as f32 * amount ) as u16
+}
+
+// Returns an i16 based on the scaled `amount` in range [0.0, 1.0]
+fn scaled_i16( amount: f32 ) -> i16 {
+  ( ( u16::MAX as f32 * amount ) - i16::MAX as f32 ) as i16
+}
+*/
+
+/*
+// Returns the estimated number of points in the DAC's internal buffer.
+fn _estimate_dac_buffer_count( state: &State, last_seen_at: &Instant ) -> usize {
+  // cpp implementation
+  //size_t buffer_count = static_cast<size_t>( dac->get_status().points_buffered );
+  //
+  //if( is_dac_playing( dac ) ) {
+  //  auto elapsed_ms = duration_cast<milliseconds>( steady_clock::now() - dac->get_last_seen_at() ).count();
+  //  auto estimated_points_consumed = elapsed_ms * ( dac->get_status().points_per_second / 1000 );
+  //
+  //  buffer_count = std::max( buffer_count - estimated_points_consumed, static_cast<size_t>( 0 ) );
+  //}
+  //
+  //return buffer_count;
+
+  let mut buffer_count = state.points_buffered;
+
+  if state.playback_state == PlaybackState::Playing {
+    let elapsed = Instant::now() - *last_seen_at;
+    let est_points_consumed = elapsed.as_millis() * ( state.points_buffered / 1000 ) as u128;
+
+    buffer_count = ( buffer_count - ( est_points_consumed as u16 ) ).max( 0 );
+  }
+
+  return buffer_count as usize;
+}
+*/

--- a/etherdream/src/lib.rs
+++ b/etherdream/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod circular_buffer;
 pub mod client;
 pub mod device;
 pub mod discovery;
@@ -5,3 +6,4 @@ pub mod discovery;
 // Convenience exports
 pub use client::Client;
 pub use device::Device;
+pub use discovery::Server as Discovery;

--- a/etherdream/tests/circular_buffer_test.rs
+++ b/etherdream/tests/circular_buffer_test.rs
@@ -1,0 +1,113 @@
+use etherdream::circular_buffer::{ CircularBuffer, PushError };
+
+#[test]
+fn buffer_push_and_pop_test() {
+  let ( mut writer, mut reader ) = CircularBuffer::<&str,2>::new();
+
+  // The buffer is empty
+  assert_eq!( reader.capacity(), 2 );
+  assert_eq!( reader.is_empty(), true );
+  assert_eq!( reader.is_full(), false );
+  assert_eq!( reader.len(), 0 );
+  assert_eq!( reader.remaining(), 2 );
+
+  assert_eq!( writer.capacity(), 2 );
+  assert_eq!( writer.is_empty(), true );
+  assert_eq!( writer.is_full(), false );
+  assert_eq!( writer.len(), 0 );
+  assert_eq!( writer.remaining(), 2 );
+
+  // The buffer has a single item
+  let _ = writer.push( "a" );
+
+  assert_eq!( reader.is_empty(), false );
+  assert_eq!( reader.is_full(), false );
+  assert_eq!( reader.len(), 1 );
+  assert_eq!( reader.remaining(), 1 );
+
+  assert_eq!( writer.is_empty(), false );
+  assert_eq!( writer.is_full(), false );
+  assert_eq!( writer.len(), 1 );
+  assert_eq!( writer.remaining(), 1 );
+
+  // The buffer is at capacity
+  let _ = writer.push( "b" );
+
+  assert_eq!( reader.is_empty(), false );
+  assert_eq!( reader.is_full(), true );
+  assert_eq!( reader.len(), 2 );
+  assert_eq!( reader.remaining(), 0 );
+
+  assert_eq!( writer.is_empty(), false );
+  assert_eq!( writer.is_full(), true );
+  assert_eq!( writer.len(), 2 );
+  assert_eq!( writer.remaining(), 0 );
+  
+  // Will return an insufficient capacity error if we attempt to push again
+  assert_eq!( writer.push( "c" ).err(), Some( PushError::InsufficientCapacity ) );
+
+  // The caller has consumed a single item
+  assert_eq!( "a", reader.pop().unwrap() );
+
+  assert_eq!( reader.is_empty(), false );
+  assert_eq!( reader.is_full(), false );
+  assert_eq!( reader.len(), 1 );
+
+  assert_eq!( writer.is_empty(), false );
+  assert_eq!( writer.is_full(), false );
+  assert_eq!( writer.len(), 1 );
+
+  // The caller has consumed all items
+  assert_eq!( "b", reader.pop().unwrap() );
+
+  assert_eq!( reader.is_empty(), true );
+  assert_eq!( reader.is_full(), false );
+  assert_eq!( reader.len(), 0 );
+
+  assert_eq!( writer.is_empty(), true );
+  assert_eq!( writer.is_full(), false );
+  assert_eq!( writer.len(), 0 );
+
+  // The buffer will return None since all items have been consumed
+  assert!( reader.pop().is_none() );
+}
+
+#[test]
+fn buffer_will_handle_rollover_test() {
+  let ( mut writer, mut reader ) = CircularBuffer::<&str,3>::new();
+
+  let _ = writer.push( "a" );
+  let _ = writer.push( "b" );
+  let _ = reader.pop();
+  let _ = writer.push( "c" );
+
+  assert_eq!( writer.is_empty(), false );
+  assert_eq!( writer.is_full(), false );
+  assert_eq!( writer.len(), 2 );
+
+  let _ = writer.push( "d" );
+  assert_eq!( writer.is_empty(), false );
+  assert_eq!( writer.is_full(), true );
+  assert_eq!( writer.len(), 3 );
+}
+
+/*
+#[test]
+fn buffer_push_from_slice_test() {
+  let mut buffer = BoundedCircularBuffer::<&str,10>::new();
+
+  let _ = buffer.push_from_slice([ "a, "b", "c" ]);
+
+  assert_eq!( buffer.is_empty(), false );
+  assert_eq!( buffer.is_full(), false );
+  assert_eq!( buffer.len(), 5 );
+  assert_eq!( buffer.capacity(), 5 );
+
+  let _ = buffer.push_from_slice( &points );
+
+  assert_eq!( buffer.is_empty(), false );
+  assert_eq!( buffer.is_full(), true );
+  assert_eq!( buffer.len(), 10 );
+  assert_eq!( buffer.capacity(), 0 );
+}
+*/


### PR DESCRIPTION
### Changelog:

- Complete refactor of the bounded SPSC circular buffer. The circular buffer is now lockless.
- Removed `Point`, as its implementation specific to the consumer of `Client`. Client now accepts point data in ILDA format.
- Ability to load an Etherdream point buffer with data (hard-coded, for now)
- Ability to play and exhaust Etherdream point buffer (DAC will enter an "underflow" state upon exhaustion)
- Removed all dependencies from the Etherdream lib beyond `tokio` (async runtime) and `tokio-utils` (cancellation token)
- Collapsed `Client::with_socket` into `Client::new`. Simplifies client interface.